### PR TITLE
Add #define nesting error

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -297,7 +297,9 @@ static const char *emessages[] = {
 #define ERR_INVALID_NUMBER            (ERROR | 26)
     "Non-number found in expression",
 #define ERR_MEMORY_OVERLAP            (ERROR | 27)
-    "Memory overwrite at address %04x"
+    "Memory overwrite at address %04x",
+#define ERR_DEFINE_NESTING_DEPTH      (ERROR | 28)
+    "#define nesting too deep"
 };
 
 static const char *wmessages[] = {
@@ -1540,7 +1542,11 @@ int defReplaceEng(char *line, unsigned recurselevel)
   int i;
   int rv=0;  // 0 means no changes
 
-  if (recurselevel > MAXDEFINERECURSE) return 0;
+  if (recurselevel > MAXDEFINERECURSE)
+    {
+      doError(ERR_DEFINE_NESTING_DEPTH);
+      return 0;
+    }
 
   for (i = 0; i < numDefines; i++)
   {


### PR DESCRIPTION
In case you want to convert the #define error to a real error. Here's a test file:

```
	#define BOGO 010h
	#define BOGO1 BOGO
// set to 1 to fail, 0 to pass	
#if 1	
	#define BOGO2 BOGO1
	#define BOGO3 BOGO2
	#define BOGO4 BOGO3
	#define MYORG BOGO4
	#else
	#define MYORG BOGO1
	#endif
	org MYORG
	ldi MYORG
	end 100h
```