### PR TITLE
Small changes to compile under Windows

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -229,16 +229,6 @@ char *strdup(const char *s)
   return p;
 }
 
-struct tm *localtime_r(const time_t *timer, struct tm *buf)
-{
-  if (buf != NULL)
-  {
-    memcpy(buf, localtime(timer), sizeof(struct tm));
-  }
-
-  return buf;
-}
-
 void list(char *message)
 {
   if (passNumber != 2)

--- a/asm.c
+++ b/asm.c
@@ -229,6 +229,16 @@ char *strdup(const char *s)
   return p;
 }
 
+struct tm *localtime_r(const time_t *timer, struct tm *buf)
+{
+  if (buf != NULL)
+  {
+    memcpy(buf, localtime(timer), sizeof(struct tm));
+  }
+
+  return buf;
+}
+
 void list(char *message)
 {
   if (passNumber != 2)

--- a/header.h
+++ b/header.h
@@ -13,7 +13,6 @@
 #include <io.h>
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
-#define localtime_r(X, Y) (localtime_s(Y, X))
 #define USE_YA_GETOPT
 #else
 #include <strings.h>

--- a/header.h
+++ b/header.h
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <strings.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include "mmap.h"
@@ -17,9 +16,20 @@
 #define localtime_r(X, Y) (localtime_s(Y, X))
 #define USE_YA_GETOPT
 #else
+#include <strings.h>
 #include <unistd.h>
 #include <sys/time.h>
 #define O_BINARY 0
+
+struct tm *localtime_r(const time_t *timer, struct tm *buf)
+{
+  if (buf != NULL)
+  {
+    memcpy(buf, localtime(timer), sizeof(struct tm));
+  }
+
+  return buf;
+}
 #endif
 
 #ifdef USE_YA_GETOPT


### PR DESCRIPTION
Two small changes so the file can be compiled under windows.

1) Strings.h header is not available in Windows, so I moved the include statement into the Non-Windows else section if the #if defined(_WIN32) || defined(_WIN64)  statement in the header.h file.

2) The function localtime_r(X, Y)  is already defined in the Windows section of the header.h file, so the redefinition in asm.c causes a compile error.  I moved the definition out of asm.c into the Non-Windows #if defined(_WIN32) || defined(_WIN64)  . . . #else section in the header.h file.

With these two changes, I can successfully compile Asm/02 under Windows. 