### PR TITLE
Updated header.h to fix Windows compile issues

### DIFF
--- a/header.h
+++ b/header.h
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <stdbool.h>
 #include "mmap.h"
+#include <time.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <io.h>
@@ -17,7 +18,6 @@
 #else
 #include <strings.h>
 #include <unistd.h>
-#include <time.h>
 #define O_BINARY 0
 #endif
 


### PR DESCRIPTION
The windows build has issues because the <time.h> header file is only included in the Linux builds.  The fix is to move the include statement for the <time.h> up into the common part of the header.h file so that is included in the Linux and Windows builds.